### PR TITLE
reduced wdr.log logging level to from DEBUG to INFO

### DIFF
--- a/lib/common/logconf.ini
+++ b/lib/common/logconf.ini
@@ -88,7 +88,7 @@ stream=sys.stdout
 
 [handler_fileLog]
 class=FileHandler
-level=DEBUG
+level=INFO
 formatter=longFormatter
 args=('wdr.log', 'w')
 filename=wdr.log


### PR DESCRIPTION
The underlying logging library calls flush, which in turn calls java/io/FileDescriptor.sync. This may force full fsync on certain filesystems and significantly impact performance.
