### PR TITLE
bugfix: making wdr.checksum independent from archive location

### DIFF
--- a/lib/common/wdr/__init__.py
+++ b/lib/common/wdr/__init__.py
@@ -6,8 +6,8 @@ __all__ = ['config', 'control', 'task', 'manifest', 'util']
 logger = logging.getLogger('wdr')
 
 MAJOR_VERSION = 0
-MINOR_VERSION = 5
-PATCH_VERSION = 1
+MINOR_VERSION = 6
+PATCH_VERSION = 0
 
 
 class WsadminObjects:

--- a/lib/common/wdr/manifest.py
+++ b/lib/common/wdr/manifest.py
@@ -851,8 +851,18 @@ class ApplicationObject:
     def __unicode__(self):
         return unicode(self.__str__())
 
+    def _canonical_string(self):
+        result = ''
+        if self.name.find(' ') == -1:
+            result += '%s\n' % self.name
+        else:
+            result += '"%s"\n' % self.name
+        result += self._str_extra_options()
+        result += self._str_options()
+        return result
+
     def checksum(self):
-        return wdr.util.sha512(str(self))
+        return wdr.util.sha512(self._canonical_string())
 
 
 class _AppEventConsumer:


### PR DESCRIPTION
The algorithm for calculating deployment checksum was environment-dependent. The manifest used as an input to checksum calculation was using actual, fully qualified path of application archive. The new algorithm does not depend on archive path at all.

There's one catch here: attempt to import existing manifests will always result in application update.