### PR TITLE
Add type HTTPInboundChannelLogging to export sets.

### DIFF
--- a/lib/common/wdr/export_sets.py
+++ b/lib/common/wdr/export_sets.py
@@ -1288,6 +1288,19 @@ def services():
                 d(attribute='properties'),
             ],
         ),
+        HTTPInboundChannelLogging=d(
+            items=[
+                d(attribute='accessLog'),
+                d(attribute='accessLogFormat'),
+                d(attribute='enableAccessLogging'),
+                d(attribute='enableErrorLogging'),
+                d(attribute='enableFRCALogging'),
+                d(attribute='errorLog'),
+                d(attribute='errorLogLevel'),
+                d(attribute='frcaLog'),
+                d(attribute='frcaLogFormat'),
+            ],
+        ),
         LogFile=d(
             items=[
                 d(attribute='filePath'),


### PR DESCRIPTION
Application servers -> 'serverName' -> Web Container Settings -> Web container transport chains -> WCInboundDefault -> Logging block (enable access logging, access log file path, ...)